### PR TITLE
Update s_pharm to have itemgroup softdrugs (WRONG FORK SORRY)

### DIFF
--- a/data/json/mapgen/pharmacy.json
+++ b/data/json/mapgen/pharmacy.json
@@ -69,7 +69,7 @@
         "1": { "item": "magazines", "chance": 50, "repeat": [ 4, 16 ] },
         "2": { "item": "snacks", "chance": 60, "repeat": [ 1, 12 ] },
         "3": { "item": "tools_home", "chance": 20, "repeat": [ 1, 3 ] },
-        "4": { "item": "softdrugs", "chance": 60, "repeat": [ 1, 6 ] }
+        "4": { "item": "softdrugs", "chance": 60, "repeat": [ 1, 6 ] },
         "5": { "item": "beauty", "chance": 60, "repeat": [ 1, 3 ] },
         "6": { "item": "vitamin_shop", "chance": 60, "repeat": [ 1, 10 ] },
         "7": { "item": "cleaning", "chance": 50, "repeat": [ 1, 6 ] },

--- a/data/json/mapgen/pharmacy.json
+++ b/data/json/mapgen/pharmacy.json
@@ -19,7 +19,7 @@
         "| ####..12...23...35...|",
         "|......................|",
         "|f......666666666666...|",
-        "|f......EEEEEEEEEEEE...|",
+        "|f......444444444444...|",
         "|f.....................|",
         "|f......777777777777...|",
         "|f......999999999999...|",
@@ -69,13 +69,13 @@
         "1": { "item": "magazines", "chance": 50, "repeat": [ 4, 16 ] },
         "2": { "item": "snacks", "chance": 60, "repeat": [ 1, 12 ] },
         "3": { "item": "tools_home", "chance": 20, "repeat": [ 1, 3 ] },
+        "4": { "item": "softdrugs", "chance": 60, "repeat": [ 1, 6 ] }
         "5": { "item": "beauty", "chance": 60, "repeat": [ 1, 3 ] },
         "6": { "item": "vitamin_shop", "chance": 60, "repeat": [ 1, 10 ] },
         "7": { "item": "cleaning", "chance": 50, "repeat": [ 1, 6 ] },
         "8": { "item": "behindcounter", "chance": 50, "repeat": [ 1, 6 ] },
         "9": { "item": "pet_food", "chance": 20, "repeat": [ 1, 3 ] },
         "L": { "item": "drugs_pharmacy", "chance": 60, "repeat": [ 1, 6 ] }
-        "E": { "item": "softdrugs", "chance": 60, "repeat": [ 1, 6 ] }
       },
       "vehicles": { ".": { "vehicle": "shopping_cart", "chance": 1, "status": 1 } },
       "place_monsters": [ { "monster": "GROUP_PHARM", "x": [ 2, 7 ], "y": [ 10, 17 ], "chance": 2 } ]

--- a/data/json/mapgen/pharmacy.json
+++ b/data/json/mapgen/pharmacy.json
@@ -19,7 +19,7 @@
         "| ####..12...23...35...|",
         "|......................|",
         "|f......666666666666...|",
-        "|f......666666666666...|",
+        "|f......EEEEEEEEEEEE...|",
         "|f.....................|",
         "|f......777777777777...|",
         "|f......999999999999...|",
@@ -75,6 +75,7 @@
         "8": { "item": "behindcounter", "chance": 50, "repeat": [ 1, 6 ] },
         "9": { "item": "pet_food", "chance": 20, "repeat": [ 1, 3 ] },
         "L": { "item": "drugs_pharmacy", "chance": 60, "repeat": [ 1, 6 ] }
+        "E": { "item": "softdrugs", "chance": 60, "repeat": [ 1, 6 ] }
       },
       "vehicles": { ".": { "vehicle": "shopping_cart", "chance": 1, "status": 1 } },
       "place_monsters": [ { "monster": "GROUP_PHARM", "x": [ 2, 7 ], "y": [ 10, 17 ], "chance": 2 } ]


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes a mistake/oversight in #35175 that removed the softdrugs itemgroup from s_pharm."

#### Purpose of change

Seems like a mistake was made in 2019 that removed "softdrugs" from s_pharm, despite it remaining in s_pharm_1.

#### Describe the solution

Replaced one of two rows of supplements with items from the softdrugs itemgroup.

#### Describe alternatives you've considered

Add antihistamines to the behindcounter itemgroup. I will likely make a PR later that does this anyway.

#### Testing

I almost never do this, but due to how simple of a change this is, I did not test it. If requested, I will, but I can see no reason this wouldn't work.

#### Additional context

I apologize for creating this PR without properly filling out this info. I meant to push it to my own fork, but accidentally sent it here. Decided it didn't matter that it was sent here instead, since there were no changes to make (C++ ones, I mean).